### PR TITLE
Improved DrawText method

### DIFF
--- a/source/SharpGL/Core/SharpGL/FontOutlines.cs
+++ b/source/SharpGL/Core/SharpGL/FontOutlines.cs
@@ -107,7 +107,7 @@ namespace SharpGL
         /// <param name="fontSize">Size of the font.</param>
         /// <param name="text">The text.</param>
         /// <param name="resWidth">Horizontal resolution.</param>
-        /// <param name="resWidth">Vertical resolution.</param>
+        /// <param name="resHeight">Vertical resolution.</param>
         public void DrawText(OpenGL gl, int x, int y, float r, float g, float b, string faceName, float fontSize, string text,
             double resWidth, double resHeight)
         {

--- a/source/SharpGL/Core/SharpGL/FontOutlines.cs
+++ b/source/SharpGL/Core/SharpGL/FontOutlines.cs
@@ -106,7 +106,10 @@ namespace SharpGL
         /// <param name="faceName">Name of the face.</param>
         /// <param name="fontSize">Size of the font.</param>
         /// <param name="text">The text.</param>
-        public void DrawText(OpenGL gl, int x, int y, float r, float g, float b, string faceName, float fontSize, string text)
+        /// <param name="resWidth">Horizontal resolution.</param>
+        /// <param name="resWidth">Vertical resolution.</param>
+        public void DrawText(OpenGL gl, int x, int y, float r, float g, float b, string faceName, float fontSize, string text,
+            double resWidth, double resHeight)
         {
             //  Get the font size in pixels.
             var fontHeight = (int)(fontSize * (16.0f / 12.0f));
@@ -125,18 +128,13 @@ namespace SharpGL
             //  If we don't have the FBE, we must create it.
             if (fontBitmapEntry == null)
                 fontBitmapEntry = CreateFontBitmapEntry(gl, faceName, fontHeight);
-
-            double width = gl.RenderContextProvider.Width;
-            double height = gl.RenderContextProvider.Height;
             
             //  Create the appropriate projection matrix.
             gl.MatrixMode(OpenGL.GL_PROJECTION);
             gl.PushMatrix();
             gl.LoadIdentity();
             
-            int[] viewport = new int[4];
-            gl.GetInteger(OpenGL.GL_VIEWPORT, viewport);
-            gl.Ortho(0, width, 0, height, -1, 1);
+            gl.Ortho(0, resWidth, 0, resHeight, -1, 1);
 
             //  Create the appropriate modelview matrix.
             gl.MatrixMode(OpenGL.GL_MODELVIEW);

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -963,7 +963,9 @@ namespace SharpGL
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColor4usv ( ushort []v);
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorMask (byte red, byte green, byte blue, byte alpha);
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorMaterial (uint face, uint mode);
-		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorPointer (int size, uint type, int stride,  IntPtr pointer);
+		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorPointer (int size, uint type, int stride, IntPtr pointer);
+        [DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorPointer(int size, uint type, int stride, byte[] pointer);
+        [DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glColorPointer(int size, uint type, int stride, float[] pointer);
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glCopyPixels (int x, int y, int width, int height, uint type);
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glCopyTexImage1D (uint target, int level, uint internalFormat, int x, int y, int width, int border);
 		[DllImport(LIBRARY_OPENGL, SetLastError = true)] private static extern void glCopyTexImage2D (uint target, int level, uint internalFormat, int x, int y, int width, int height, int border);
@@ -1991,11 +1993,39 @@ namespace SharpGL
         /// <summary>
         /// Define an array of colors.
         /// </summary>
-        /// <param name="size">Specifies the number	of components per color. Must be 3	or 4.</param>
+        /// <param name="size">Specifies the number	of components per color. Must be 3 or 4.</param>
         /// <param name="type">Specifies the data type of each color component in the array. Symbolic constants OpenGL.BYTE, OpenGL.UNSIGNED_BYTE, OpenGL.SHORT, OpenGL.UNSIGNED_SHORT, OpenGL.INT, OpenGL.UNSIGNED_INT, OpenGL.FLOAT and OpenGL.DOUBLE are accepted.</param>
         /// <param name="stride">Specifies the byte offset between consecutive colors. If stride is 0, (the initial value), the colors are understood to be tightly packed in the array.</param>
         /// <param name="pointer">Specifies a pointer to the first component of the first color element in the array.</param>
 		public void ColorPointer (int size, uint type, int stride,  IntPtr pointer)
+        {
+            PreGLCall();
+            glColorPointer(size, type, stride, pointer);
+            PostGLCall();
+        }
+
+        /// <summary>
+        /// Define an array of colors.
+        /// </summary>
+        /// <param name="size">Specifies the number	of components per color. Must be 3 or 4.</param>
+        /// <param name="type">Specifies the data type of each color component in the array. Symbolic constants OpenGL.BYTE, OpenGL.UNSIGNED_BYTE, OpenGL.SHORT, OpenGL.UNSIGNED_SHORT, OpenGL.INT, OpenGL.UNSIGNED_INT, OpenGL.FLOAT and OpenGL.DOUBLE are accepted.</param>
+        /// <param name="stride">Specifies the byte offset between consecutive colors. If stride is 0, (the initial value), the colors are understood to be tightly packed in the array.</param>
+        /// <param name="pointer">The array.</param>
+        public void ColorPointer(int size, uint type, int stride, byte[] pointer)
+        {
+            PreGLCall();
+            glColorPointer(size, type, stride, pointer);
+            PostGLCall();
+        }
+
+        /// <summary>
+        /// Define an array of colors.
+        /// </summary>
+        /// <param name="size">Specifies the number	of components per color. Must be 3 or 4.</param>
+        /// <param name="type">Specifies the data type of each color component in the array. Symbolic constants OpenGL.BYTE, OpenGL.UNSIGNED_BYTE, OpenGL.SHORT, OpenGL.UNSIGNED_SHORT, OpenGL.INT, OpenGL.UNSIGNED_INT, OpenGL.FLOAT and OpenGL.DOUBLE are accepted.</param>
+        /// <param name="stride">Specifies the byte offset between consecutive colors. If stride is 0, (the initial value), the colors are understood to be tightly packed in the array.</param>
+        /// <param name="pointer">The array.</param>
+        public void ColorPointer(int size, uint type, int stride, float[] pointer)
         {
             PreGLCall();
             glColorPointer(size, type, stride, pointer);

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6837,7 +6837,30 @@ if (insideGLBegin == false)
             string faceName, float fontSize, string text)
         {
             //  Use the font bitmaps object to render the text.
-            fontBitmaps.DrawText(this, x, y, r, g, b, faceName, fontSize, text);
+            fontBitmaps.DrawText(this, x, y, r, g, b, faceName, fontSize, text,
+                renderContextProvider.Width, renderContextProvider.Height);
+        }
+
+        /// <summary>
+        /// Draws the text.
+        /// </summary>
+        /// <param name="x">The x.</param>
+        /// <param name="y">The y.</param>
+        /// <param name="r">The r.</param>
+        /// <param name="g">The g.</param>
+        /// <param name="b">The b.</param>
+        /// <param name="faceName">Name of the face.</param>
+        /// <param name="fontSize">Size of the font.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="resWidth">Horizontal resolution.</param>
+        /// <param name="resWidth">Vertical resolution.</param>
+        public void DrawText(int x, int y, float r, float g, float b,
+            string faceName, float fontSize, string text,
+            int resWidth, int resHeight)
+        {
+            //  Use the font bitmaps object to render the text.
+            fontBitmaps.DrawText(this, x, y, r, g, b, faceName, fontSize, text,
+                resWidth, resHeight);
         }
 
         /// <summary>

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6836,8 +6836,7 @@ if (insideGLBegin == false)
         public void DrawText(int x, int y, float r, float g, float b, 
             string faceName, float fontSize, string text)
         {
-            //  Use the font bitmaps object to render the text.
-            fontBitmaps.DrawText(this, x, y, r, g, b, faceName, fontSize, text,
+            DrawText(x, y, r, g, b, faceName, fontSize, text,
                 renderContextProvider.Width, renderContextProvider.Height);
         }
 
@@ -6853,7 +6852,7 @@ if (insideGLBegin == false)
         /// <param name="fontSize">Size of the font.</param>
         /// <param name="text">The text.</param>
         /// <param name="resWidth">Horizontal resolution.</param>
-        /// <param name="resWidth">Vertical resolution.</param>
+        /// <param name="resHeight">Vertical resolution.</param>
         public void DrawText(int x, int y, float r, float g, float b,
             string faceName, float fontSize, string text,
             int resWidth, int resHeight)


### PR DESCRIPTION
Added possibility to specify the resolution for text drawing so it's possible to position text correctly when using own orthogonal projection that differs from rendering context dimensions.

Example:

If you call glOthro/glOrtho2D in your program to render 2D stuff with dimensions that don't match the size of the render context the coordinates of the DrawText method won't match the coordinates of other rendered 2D stuff as DrawText will call its own glOrtho but with different dimensions.

This is especially annoying if one uses a virtual screen with a fixed resolution that is independent of the render context dimensions.

Changes:

I added a second DrawText method with two additional parameters that allow to specify the preferred dimensions / resolution. The normal DrawText method remains and will exactly work as before so there won't be any breaking changes.
