### PR TITLE
Forgotten increment in drawing mechanisms sample

### DIFF
--- a/source/SharpGL/Samples/WPF/DrawingMechanismsSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/DrawingMechanismsSample/MainWindow.xaml.cs
@@ -98,7 +98,7 @@ namespace DrawingMechanismsSample
             uint counter = 0;
             for (uint i = 0; i < vertices.Length; i++)
             {
-                vertexArrayValues[counter] = vertices[i].X;
+                vertexArrayValues[counter++] = vertices[i].X;
                 vertexArrayValues[counter++] = vertices[i].Y;
                 vertexArrayValues[counter++] = vertices[i].Z;
             }


### PR DESCRIPTION
The VertexArray-Method did not work properly, since the values were not copied correctly to the 'vertexArrayValues' because of a forgotten '++'-Increment.