### PR TITLE
Support RoutedEvents

### DIFF
--- a/source/SharpGL/Core/SharpGL.WPF/OpenGLRoutedEventArgs.cs
+++ b/source/SharpGL/Core/SharpGL.WPF/OpenGLRoutedEventArgs.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows;
+
+namespace SharpGL.WPF
+{
+    public class OpenGLRoutedEventArgs : RoutedEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenGLRoutedEventArgs"/> class.
+        /// </summary>
+        /// <param name="gl">The gl.</param>
+        public OpenGLRoutedEventArgs(RoutedEvent routedEvent, OpenGL gl)
+            : base(routedEvent)
+        {
+            OpenGL = gl;
+        }
+
+        /// <summary>
+        /// The OpenGL instance.
+        /// </summary>
+        private OpenGL gl = null;
+
+        /// <summary>
+        /// Gets or sets the open GL.
+        /// </summary>
+        /// <value>The open GL.</value>
+        public OpenGL OpenGL
+        {
+            get { return gl; }
+            private set { gl = value; }
+        }
+    }
+
+    /// <summary>
+    /// The OpenGL Event Handler delegate.
+    /// </summary>
+    public delegate void OpenGLRoutedEventHandler(object sender, OpenGLRoutedEventArgs args);
+}

--- a/source/SharpGL/Core/SharpGL.WPF/SharpGL.WPF.csproj
+++ b/source/SharpGL/Core/SharpGL.WPF/SharpGL.WPF.csproj
@@ -72,6 +72,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CollectionCountToVisibilityConverter.cs" />
+    <Compile Include="OpenGLRoutedEventArgs.cs" />
     <Compile Include="SceneTree\SceneTree.xaml.cs">
       <DependentUpon>SceneTree.xaml</DependentUpon>
     </Compile>

--- a/source/SharpGL/Samples/WPF/CelShadingSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/CelShadingSample/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using SharpGL;
 using SharpGL.SceneGraph.Core;
 using SharpGL.SceneGraph.Primitives;
 using SharpGL.SceneGraph;
+using SharpGL.WPF;
 
 namespace CelShadingSample
 {
@@ -16,7 +17,7 @@ namespace CelShadingSample
             InitializeComponent();
         }
 
-        private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance.
             var gl = args.OpenGL;	
@@ -46,7 +47,7 @@ namespace CelShadingSample
             }
         }
         
-        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;
             
@@ -54,7 +55,7 @@ namespace CelShadingSample
             scene.Initialise(gl);
         }
 
-        private void OpenGLControl_Resized(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_Resized(object sender, OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance.
             var gl = args.OpenGL;       

--- a/source/SharpGL/Samples/WPF/DrawingMechanismsSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/DrawingMechanismsSample/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using SharpGL.SceneGraph;
 using SharpGL.SceneGraph.Cameras;
 using SharpGL.SceneGraph.Core;
 using SharpGL.SceneGraph.Primitives;
+using SharpGL.WPF;
 
 namespace DrawingMechanismsSample
 {
@@ -30,7 +31,7 @@ namespace DrawingMechanismsSample
             InitializeComponent();
         }
 
-        private void openGLCtrl_OpenGLDraw(object sender, SharpGL.SceneGraph.OpenGLEventArgs args)
+        private void openGLCtrl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance that's been passed to us.
             OpenGL gl = args.OpenGL;
@@ -86,7 +87,7 @@ namespace DrawingMechanismsSample
             gl.DisableClientState(OpenGL.GL_VERTEX_ARRAY);
         }
 
-        private void openGLCtrl_OpenGLInitialized(object sender, SharpGL.SceneGraph.OpenGLEventArgs args)
+        private void openGLCtrl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             //  Create the vertices.
             vertices = GeometryGenerator.GenerateGeometry(Properties.Settings.Default.NumberOfVertices, 1f);

--- a/source/SharpGL/Samples/WPF/ObjectLoadingSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/ObjectLoadingSample/MainWindow.xaml.cs
@@ -17,6 +17,7 @@ using SharpGL.Enumerations;
 using SharpGL.SceneGraph;
 using SharpGL.SceneGraph.Core;
 using SharpGL.SceneGraph.Primitives;
+using SharpGL.WPF;
 
 namespace ObjectLoadingSample
 {
@@ -30,7 +31,7 @@ namespace ObjectLoadingSample
             InitializeComponent();
         }
 
-        private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance.
             var gl = args.OpenGL;
@@ -54,7 +55,7 @@ namespace ObjectLoadingSample
             }
         }
 
-        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;
 
@@ -64,7 +65,7 @@ namespace ObjectLoadingSample
             gl.Enable(OpenGL.GL_DEPTH_TEST);
         }
 
-        private void OpenGLControl_Resized(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_Resized(object sender, OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance.
             var gl = args.OpenGL;

--- a/source/SharpGL/Samples/WPF/SimpleShaderSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/SimpleShaderSample/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ using SharpGL;
 using SharpGL.SceneGraph.Primitives;
 using SharpGL.SceneGraph.Shaders;
 using SharpGL.SceneGraph;
+using SharpGL.WPF;
 
 namespace SimpleShaderSample
 {
@@ -28,7 +29,7 @@ namespace SimpleShaderSample
             InitializeComponent();
         }
 
-        private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;	
             
@@ -51,7 +52,7 @@ namespace SimpleShaderSample
 
         float rotation = 0;
 
-        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
+        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;
 

--- a/source/SharpGL/Samples/WPF/TeapotSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/TeapotSample/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Shapes;
 using SharpGL;
 using SharpGL.SceneGraph.Primitives;
 using SharpGL.SceneGraph;
+using SharpGL.WPF;
 
 namespace Example1
 {
@@ -34,8 +35,8 @@ namespace Example1
         /// Handles the OpenGLDraw event of the OpenGLControl control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
-        /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
-        private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
+        /// <param name="args">The <see cref="SharpGL.WPF.OpenGLRoutedEventArgs"/> instance containing the event data.</param>
+        private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;	
             
@@ -61,8 +62,8 @@ namespace Example1
         /// Handles the OpenGLInitialized event of the OpenGLControl control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
-        /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
-        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
+        /// <param name="args">The <see cref="SharpGL.WPF.OpenGLRoutedEventArgs"/> instance containing the event data.</param>
+        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;
 

--- a/source/SharpGL/Samples/WPF/TextRenderingSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/TextRenderingSample/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Shapes;
 using SharpGL;
 using SharpGL.SceneGraph.Primitives;
 using SharpGL.SceneGraph;
+using SharpGL.WPF;
 
 namespace TextRenderingSample
 {
@@ -31,8 +32,8 @@ namespace TextRenderingSample
         /// Handles the OpenGLDraw event of the OpenGLControl control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
-        /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
-        private void OpenGLControl_OpenGLDraw(object sender, OpenGLEventArgs args)
+        /// <param name="args">The <see cref="SharpGL.WPF.OpenGLRoutedEventArgs"/> instance containing the event data.</param>
+        private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;	
             
@@ -65,8 +66,8 @@ namespace TextRenderingSample
         /// Handles the OpenGLInitialized event of the OpenGLControl control.
         /// </summary>
         /// <param name="sender">The source of the event.</param>
-        /// <param name="args">The <see cref="SharpGL.SceneGraph.OpenGLEventArgs"/> instance containing the event data.</param>
-        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLEventArgs args)
+        /// <param name="args">The <see cref="SharpGL.WPF.OpenGLRoutedEventArgs"/> instance containing the event data.</param>
+        private void OpenGLControl_OpenGLInitialized(object sender, OpenGLRoutedEventArgs args)
         {
             OpenGL gl = args.OpenGL;
 

--- a/source/SharpGL/Samples/WPF/TwoDSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/TwoDSample/MainWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace TwoDSample
             InitializeComponent();
         }
         
-        private void openGLControl1_OpenGLDraw(object sender, SharpGL.SceneGraph.OpenGLEventArgs args)
+        private void openGLControl1_OpenGLDraw(object sender, SharpGL.WPF.OpenGLRoutedEventArgs args)
         {
             //  If there aren't any shapes, create them.
             if (!shapes.Any())
@@ -128,7 +128,7 @@ namespace TwoDSample
             return random.NextDouble()*(maximum - minimum) + minimum;
         }
 
-        private void openGLControl1_Resized(object sender, SharpGL.SceneGraph.OpenGLEventArgs args)
+        private void openGLControl1_Resized(object sender, SharpGL.WPF.OpenGLRoutedEventArgs args)
         {
             //  Get the OpenGL instance.
             var gl = args.OpenGL;


### PR DESCRIPTION
If you program MVVM style, you should implement 'RoutedEvents' instead of normal events, otherwise, the events will not be captures correctly.