### PR TITLE
bug: remove the non-functional 'fontSize' parameter from DrawText3D

### DIFF
--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -7155,14 +7155,13 @@ if (insideGLBegin == false)
         /// Draws 3D text.
         /// </summary>
         /// <param name="faceName">Name of the face.</param>
-        /// <param name="fontSize">Size of the font.</param>
         /// <param name="deviation">The deviation.</param>
         /// <param name="extrusion">The extrusion.</param>
         /// <param name="text">The text.</param>
-        public void DrawText3D(string faceName, float fontSize, float deviation, float extrusion, string text)
+        public void DrawText3D(string faceName, float deviation, float extrusion, string text)
         {
             //  Use the font outlines object to render the text.
-            fontOutlines.DrawText(this, faceName, fontSize, deviation, extrusion, text); 
+            fontOutlines.DrawText(this, faceName, deviation, extrusion, text); 
         }
 
 #region Member Variables

--- a/source/SharpGL/Samples/WPF/TextRenderingSample/MainWindow.xaml.cs
+++ b/source/SharpGL/Samples/WPF/TextRenderingSample/MainWindow.xaml.cs
@@ -21,21 +21,19 @@ namespace TextRenderingSample
         /// <param name="args">The <see cref="OpenGLRoutedEventArgs"/> instance containing the event data.</param>
         private void OpenGLControl_OpenGLDraw(object sender, OpenGLRoutedEventArgs args)
         {
-            OpenGL gl = args.OpenGL;	
+            var gl = args.OpenGL;	
             
-            // Clear The Screen And The Depth Buffer
+            //  Clear the screen and the depth buffer.
             gl.Clear(OpenGL.GL_COLOR_BUFFER_BIT | OpenGL.GL_DEPTH_BUFFER_BIT);
             
-            // Move Left And Into The Screen
-            gl.LoadIdentity();		
-
-
+            //  Reset the projection matrix, move left and into the screen, scale the font.
+            gl.LoadIdentity();
             gl.Translate(0f, 0.0f, -6.0f);
             gl.Rotate(rotation, 1.0f, 0.0f, 0.0f);
+            var scale = viewModel.FontSize3D / 12.0f;
+            gl.Scale(scale, scale, scale);
 
-
-            gl.DrawText3D(viewModel.FaceName3D, viewModel.FontSize3D,
-                viewModel.Deviation3D, viewModel.Extrusion3D, viewModel.Text3D);
+            gl.DrawText3D(viewModel.FaceName3D, viewModel.Deviation3D, viewModel.Extrusion3D, viewModel.Text3D);
 
             rotation += 3.0f;
 


### PR DESCRIPTION
The fontsize parameter doesn't (and cannot) work. Instead, perform a
scale transformation before rendering the text.

Closes #148.