### PR TITLE
Improve speed of looking up OpenGL extension functions

### DIFF
--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6966,26 +6966,6 @@ if (insideGLBegin == false)
         }
 
 #endregion
-        
-#region Utility Functions
-
-		/// <summary>
-		/// This function transforms a windows point into an OpenGL point,
-		/// which is measured from the bottom left of the screen.
-		/// </summary>
-		/// <param name="x">The x coord.</param>
-		/// <param name="y">The y coord.</param>
-		public void GDItoOpenGL(ref int x, ref int y)
-		{
-			//	Create an array that will be the viewport.
-			var viewport = new int[4];
-			
-			//	Get the viewport, then convert the mouse point to an opengl point.
-			GetInteger(GL_VIEWPORT, viewport);
-			y = viewport[3] - y;
-		}
-
-#endregion
 
 #region Utility Functions
 

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6916,17 +6916,14 @@ namespace SharpGL
 		{
             //  If we are in debug mode, clear the error flag.
 #if DEBUG
-            // GetError() should not be called at all inside glBegin-glEnd
-            if (insideGLBegin == false)
-            {
-                GetError();
-                // ftlPhysicsGuy
-                // Clear Errors, noting any errors still in the buffer
-                CheckErrors(10, true);
-            }
+      // GetError() should not be called at all inside glBegin-glEnd
+if (insideGLBegin == false)
+{
+            GetError();
+      }
 #endif
 
-            //  If we are not the current OpenGL object, make ourselves current.
+      //  If we are not the current OpenGL object, make ourselves current.
             if (currentOpenGLInstance != this)
             {
                 MakeCurrent();
@@ -6943,64 +6940,17 @@ namespace SharpGL
             //  are not in a glBegin function.
             if (insideGLBegin == false)
             {
-                // ftlPhysicsGuy:
-				// Call CheckErrors to report on any errors encountered (accommodates multiple errors)
-                CheckErrors(10, false);
+                //	This error check is very useful, as you can break anytime 
+                //	an OpenGL error occurs, going through a program with this on
+                //	can rid it of bugs. It's VERY slow though, as every call is monitored.
+                uint errorCode = GetError();
 
-                ////	This error check is very useful, as you can break anytime 
-                ////	an OpenGL error occurs, going through a program with this on
-                ////	can rid it of bugs. It's VERY slow though, as every call is monitored.
-                //uint errorCode = GetError();
-
-                ////	What error is it?
-                //if (errorCode != GL_NO_ERROR)
-                //{
-                //    //  Get the error message.
-                //    var errorMessage = GetErrorDescription(errorCode);
-
-                //    //  Create a stack trace.
-                //    var stackTrace = new StackTrace();
-
-                //    //  Get the stack frames.
-                //    var stackFrames = stackTrace.GetFrames();
-
-                //    //  Write the error to the trace log.
-                //    var functionName = (stackFrames != null && stackFrames.Length > 1) ? stackFrames[1].GetMethod().Name : "Unknown Function";
-                //    Trace.WriteLine("OpenGL Error: \"" + errorMessage + "\", when calling function SharpGL." + functionName);
-                //}
-            }
-#endif
-        }
-
-        /// <summary>
-		/// ftlPhysicsGuy: Added to make a consistent method for accommodating multiple errors.
-        /// Calls GetErrors and uses the return value in a Trace.WriteLine call to report any
-        /// errors found.  Because there can be multiple errors, the call to GetErrors is
-        /// performed in a loop until no errors are found or until the loop has been executed for
-        /// a given maximum number of counts.
-        /// </summary>
-        /// <param name="maxLoopCount">Maximum number of times to report new errors before giving up</param>
-        /// <param name="clearingErrors">True if using CheckErrors to clear any existing errors (checks for any errors already in the buffer that have not yet been reported).</param>
-        protected void CheckErrors(int maxLoopCount, bool clearingErrors)
-        {
-            if (renderContextProvider == null) return;
-            // This error check is very useful, as you can break anytime 
-            // an OpenGL error occurs, going through a program with this on
-            // can rid it of bugs. It's VERY slow though, as every call is monitored.
-            uint errorCode = GetError();
-
-            int loopCount = 0;
-            while (errorCode != GL_NO_ERROR && loopCount < maxLoopCount) // JWH: added while loop with count checks
-            {
-                //  Get the error message.
-                var errorMessage = GetErrorDescription(errorCode);
-
-                if (clearingErrors)
+                //	What error is it?
+                if (errorCode != GL_NO_ERROR)
                 {
-                    Trace.WriteLine("OpenGL Error: when trying to CLEAR errors, found an old, unreported error: \"" + errorMessage + "\"");
-                }
-                else
-                {
+                    //  Get the error message.
+                    var errorMessage = GetErrorDescription(errorCode);
+
                     //  Create a stack trace.
                     var stackTrace = new StackTrace();
 
@@ -7008,20 +6958,35 @@ namespace SharpGL
                     var stackFrames = stackTrace.GetFrames();
 
                     //  Write the error to the trace log.
-                    var functionName = (stackFrames != null && stackFrames.Length > 2) ? stackFrames[2].GetMethod().Name : "Unknown Function";
+                    var functionName = (stackFrames != null && stackFrames.Length > 1) ? stackFrames[1].GetMethod().Name : "Unknown Function";
                     Trace.WriteLine("OpenGL Error: \"" + errorMessage + "\", when calling function SharpGL." + functionName);
                 }
-
-                // Loop until all errors are checked and reset:
-                errorCode = GetError();
-                loopCount++;
             }
-            if (loopCount >= maxLoopCount)
-                Trace.WriteLine("PreGLCall Error: looped with GetError() " + maxLoopCount + " times without clearing GL errors");
+#endif
         }
 
 #endregion
         
+#region Utility Functions
+
+		/// <summary>
+		/// This function transforms a windows point into an OpenGL point,
+		/// which is measured from the bottom left of the screen.
+		/// </summary>
+		/// <param name="x">The x coord.</param>
+		/// <param name="y">The y coord.</param>
+		public void GDItoOpenGL(ref int x, ref int y)
+		{
+			//	Create an array that will be the viewport.
+			var viewport = new int[4];
+			
+			//	Get the viewport, then convert the mouse point to an opengl point.
+			GetInteger(GL_VIEWPORT, viewport);
+			y = viewport[3] - y;
+		}
+
+#endregion
+
 #region Utility Functions
 
 		/// <summary>


### PR DESCRIPTION
The OpenGLExtensions.cs file in this commit (you can ignore the whitespace changes in OpenGL.cs) provides a faster method for finding a given OpenGL extension function.  Rather than creating the delegate for a given type name and putting it in a dictionary for lookup, this new code introduces a static, generic class that can be generated at runtime for any needed delegate type and provides the delegate as a property of the class (generated the first time it is called).  In this way, we're letting the application auto-generate or retrieve (if previously generated) the static instance of the class to provide the delegate instead of using a slower dictionary lookup.  Testing with 15 items in the dictionary shows about 7 times better performance.  While the action is incredibly fast either way, I figure faster should be better (and perhaps more elegant -- though that's matter of taste).

This is one of several modifications I make to the SharpGL source code any time I download the latest version for use in my projects. I intent to put out individual pull requests for each of them, hoping to improve the project for all. Thank you for your consideration.