### PR TITLE
OpenGL 4 additions to OpenGLExtensions.cs 

### DIFF
--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6966,26 +6966,6 @@ if (insideGLBegin == false)
         }
 
 #endregion
-        
-#region Utility Functions
-
-		/// <summary>
-		/// This function transforms a windows point into an OpenGL point,
-		/// which is measured from the bottom left of the screen.
-		/// </summary>
-		/// <param name="x">The x coord.</param>
-		/// <param name="y">The y coord.</param>
-		public void GDItoOpenGL(ref int x, ref int y)
-		{
-			//	Create an array that will be the viewport.
-			var viewport = new int[4];
-			
-			//	Get the viewport, then convert the mouse point to an opengl point.
-			GetInteger(GL_VIEWPORT, viewport);
-			y = viewport[3] - y;
-		}
-
-#endregion
 
 #region Utility Functions
 

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6966,7 +6966,7 @@ if (insideGLBegin == false)
         }
 
 #endregion
-
+        
 #region Utility Functions
 
 		/// <summary>

--- a/source/SharpGL/Core/SharpGL/OpenGL.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGL.cs
@@ -6916,17 +6916,14 @@ namespace SharpGL
 		{
             //  If we are in debug mode, clear the error flag.
 #if DEBUG
-            // GetError() should not be called at all inside glBegin-glEnd
-            if (insideGLBegin == false)
-            {
-                GetError();
-                // ftlPhysicsGuy
-                // Clear Errors, noting any errors still in the buffer
-                CheckErrors(10, true);
-            }
+      // GetError() should not be called at all inside glBegin-glEnd
+if (insideGLBegin == false)
+{
+            GetError();
+      }
 #endif
 
-            //  If we are not the current OpenGL object, make ourselves current.
+      //  If we are not the current OpenGL object, make ourselves current.
             if (currentOpenGLInstance != this)
             {
                 MakeCurrent();
@@ -6943,64 +6940,17 @@ namespace SharpGL
             //  are not in a glBegin function.
             if (insideGLBegin == false)
             {
-                // ftlPhysicsGuy:
-				// Call CheckErrors to report on any errors encountered (accommodates multiple errors)
-                CheckErrors(10, false);
+                //	This error check is very useful, as you can break anytime 
+                //	an OpenGL error occurs, going through a program with this on
+                //	can rid it of bugs. It's VERY slow though, as every call is monitored.
+                uint errorCode = GetError();
 
-                ////	This error check is very useful, as you can break anytime 
-                ////	an OpenGL error occurs, going through a program with this on
-                ////	can rid it of bugs. It's VERY slow though, as every call is monitored.
-                //uint errorCode = GetError();
-
-                ////	What error is it?
-                //if (errorCode != GL_NO_ERROR)
-                //{
-                //    //  Get the error message.
-                //    var errorMessage = GetErrorDescription(errorCode);
-
-                //    //  Create a stack trace.
-                //    var stackTrace = new StackTrace();
-
-                //    //  Get the stack frames.
-                //    var stackFrames = stackTrace.GetFrames();
-
-                //    //  Write the error to the trace log.
-                //    var functionName = (stackFrames != null && stackFrames.Length > 1) ? stackFrames[1].GetMethod().Name : "Unknown Function";
-                //    Trace.WriteLine("OpenGL Error: \"" + errorMessage + "\", when calling function SharpGL." + functionName);
-                //}
-            }
-#endif
-        }
-
-        /// <summary>
-		/// ftlPhysicsGuy: Added to make a consistent method for accommodating multiple errors.
-        /// Calls GetErrors and uses the return value in a Trace.WriteLine call to report any
-        /// errors found.  Because there can be multiple errors, the call to GetErrors is
-        /// performed in a loop until no errors are found or until the loop has been executed for
-        /// a given maximum number of counts.
-        /// </summary>
-        /// <param name="maxLoopCount">Maximum number of times to report new errors before giving up</param>
-        /// <param name="clearingErrors">True if using CheckErrors to clear any existing errors (checks for any errors already in the buffer that have not yet been reported).</param>
-        protected void CheckErrors(int maxLoopCount, bool clearingErrors)
-        {
-            if (renderContextProvider == null) return;
-            // This error check is very useful, as you can break anytime 
-            // an OpenGL error occurs, going through a program with this on
-            // can rid it of bugs. It's VERY slow though, as every call is monitored.
-            uint errorCode = GetError();
-
-            int loopCount = 0;
-            while (errorCode != GL_NO_ERROR && loopCount < maxLoopCount) // JWH: added while loop with count checks
-            {
-                //  Get the error message.
-                var errorMessage = GetErrorDescription(errorCode);
-
-                if (clearingErrors)
+                //	What error is it?
+                if (errorCode != GL_NO_ERROR)
                 {
-                    Trace.WriteLine("OpenGL Error: when trying to CLEAR errors, found an old, unreported error: \"" + errorMessage + "\"");
-                }
-                else
-                {
+                    //  Get the error message.
+                    var errorMessage = GetErrorDescription(errorCode);
+
                     //  Create a stack trace.
                     var stackTrace = new StackTrace();
 
@@ -7008,20 +6958,35 @@ namespace SharpGL
                     var stackFrames = stackTrace.GetFrames();
 
                     //  Write the error to the trace log.
-                    var functionName = (stackFrames != null && stackFrames.Length > 2) ? stackFrames[2].GetMethod().Name : "Unknown Function";
+                    var functionName = (stackFrames != null && stackFrames.Length > 1) ? stackFrames[1].GetMethod().Name : "Unknown Function";
                     Trace.WriteLine("OpenGL Error: \"" + errorMessage + "\", when calling function SharpGL." + functionName);
                 }
-
-                // Loop until all errors are checked and reset:
-                errorCode = GetError();
-                loopCount++;
             }
-            if (loopCount >= maxLoopCount)
-                Trace.WriteLine("PreGLCall Error: looped with GetError() " + maxLoopCount + " times without clearing GL errors");
+#endif
         }
 
 #endregion
         
+#region Utility Functions
+
+		/// <summary>
+		/// This function transforms a windows point into an OpenGL point,
+		/// which is measured from the bottom left of the screen.
+		/// </summary>
+		/// <param name="x">The x coord.</param>
+		/// <param name="y">The y coord.</param>
+		public void GDItoOpenGL(ref int x, ref int y)
+		{
+			//	Create an array that will be the viewport.
+			var viewport = new int[4];
+			
+			//	Get the viewport, then convert the mouse point to an opengl point.
+			GetInteger(GL_VIEWPORT, viewport);
+			y = viewport[3] - y;
+		}
+
+#endregion
+
 #region Utility Functions
 
 		/// <summary>

--- a/source/SharpGL/Core/SharpGL/OpenGLExtensions.cs
+++ b/source/SharpGL/Core/SharpGL/OpenGLExtensions.cs
@@ -2420,6 +2420,23 @@ namespace SharpGL
 
         #endregion
 
+        #region OpenGL 4.0 Additions (ftlPhysicsGuy)
+        //  Methods        
+        public void PatchParameter(uint pname, uint value)
+        {
+            GetDelegateFor<glPatchParameteri>()(pname, value);
+        }
+
+        private delegate void glPatchParameteri(uint pname, uint value);
+
+        // Constants
+        public const uint GL_TESS_EVALUATION_SHADER = 0x8e87;
+        public const uint GL_TESS_CONTROL_SHADER = 0x8e88;
+        public const uint GL_PATCH_VERTICES = 0x8E72; //36466;
+        public const uint GL_PATCH_DEFAULT_INNER_LEVEL = 0x8E73;
+        public const uint GL_PATCH_DEFAULT_OUTER_LEVEL = 0x8E74;
+        #endregion
+
         #region GL_EXT_texture3D
 
         /// <summary>


### PR DESCRIPTION
Modifies OpenGLExtensions.cs by adding the ability to call glPatchParametri and adding constants related to tessellation shaders and patches: GL_TESS_EVALUATION_SHADER, GL_TESS_CONTROL_SHADER, GL_PATCH_VERTICES, GL_PATCH_DEFAULT_INNER_LEVEL, GL_PATCH_DEFAULT_OUTER_LEVEL